### PR TITLE
Enable ARM build

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -9,7 +9,7 @@
   "type": "service",
   "author": "Nabsku <thenabsku@gmail.com> (https://github.com/Nabsku)",
   "contributors": ["Nabsku <thenabsku@gmail.com> (https://github.com/Nabsku)"],
-  "architectures": ["linux/amd64"],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "categories": ["Economic incentive"],
   "links": {
     "endpoint": "http://mev-boost-holesky.mev-boost.dappnode:18550",


### PR DESCRIPTION
Enabling ARM build. Same as https://github.com/dappnode/DAppNodePackage-mev-boost/commit/8b4e01a4e3963b7a27edbb242a1a83e78ff71cda